### PR TITLE
Fix build libs on HP-UX 11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ status, _ = commands.getstatusoutput("nm %s | grep tpappthr" % (os.path.join(tux
 tux10 = not status
 if tuxversion == 0 and tux10 == True:
     print "*** Building for Tuxedo Version > 10  ... ***"
-    tuxversion = 8
+    tuxversion = 10
 elif tuxversion == 0 and tux8 == True:
     print "*** Building for Tuxedo Version > 8  ... ***"
-    tuxversion = 10
+    tuxversion = 8
 else:
     print "*** Building for Tuxedo 6.x ... ***"
     tuxversion = 6

--- a/setup.py
+++ b/setup.py
@@ -59,19 +59,21 @@ elif os.name == 'posix':
     include_dirs = [my_inc, tuxedo_dir + '/include',  '/usr/include']
     library_dirs = [tuxedo_dir + '/lib', '/usr/lib']
 
-    if tuxversion < 7:
-	libraries = ['tux', 'tmib', 'qm', 'buft', 'tux2', 'fml', 'fml32', 'gp', '/usr/lib/libcrypt.a']
-	libraries_ws = ['wsc', 'buft', 'wsc', 'nws', 'nwi', 'nws', 'fml', 'fml32', 'gp', 'nsl', 'socket', '/usr/lib/libcrypt.a']
+    if sys.platform.startswith('hp-ux'):
+        libcrypt = ['Csup', 'unwind']
     else:
-	libraries = ['tux', 'tmib', 'buft', 'fml', 'fml32', '/usr/lib/libcrypt.a']
-	libraries_ws = ['wsc', 'tmib', 'buft', 'fml', 'fml32', 'gpnet', 'engine', 'dl', 'pthread', '/usr/lib/libcrypt.a']
-	
+        libcrypt = ['/usr/lib/libcrypt.a']
 
+    if tuxversion < 7:
+        libraries = ['tux', 'tmib', 'qm', 'buft', 'tux2', 'fml', 'fml32', 'gp'] + libcrypt
+        libraries_ws = ['wsc', 'buft', 'wsc', 'nws', 'nwi', 'nws', 'fml', 'fml32', 'gp', 'nsl', 'socket'] + libcrypt
+    else:
+        libraries = ['tux', 'tmib', 'buft', 'fml', 'fml32'] + libcrypt
+        libraries_ws = ['wsc', 'tmib', 'buft', 'fml', 'fml32', 'gpnet', 'engine', 'dl', 'pthread'] + libcrypt
 
 # For debug purposes only, set if you experience core dumps
 #extra_compile_args.append("-DDEBUG")
 #extra_compile_args.append("-g")
-
 
 # build the atmi and atmi/WS modules
 tuxedo_ext = Extension(name = 'tuxedo.atmi',

--- a/tuxconvert.c
+++ b/tuxconvert.c
@@ -67,6 +67,14 @@ PyObject* fml_to_dict(FBFR32* fml) {
 	    pyval = Py_BuildValue("i", longval);
 	    PyList_Append(list, pyval);
 	    Py_DECREF(pyval);  /* reference now owned by list */
+	}  else if (strcmp(type, "short") == 0) {
+	    short shortval = 0;
+	    FLDLEN32 shortlen  = sizeof (short);
+	    PyObject* pyval;
+	    Fget32(fml, id, oc, (char*)&shortval, &shortlen);
+	    pyval = Py_BuildValue("i", (long) shortval);
+	    PyList_Append(list, pyval);
+	    Py_DECREF(pyval);  /* reference now owned by list */
 	}  else if (strcmp(type, "double") == 0) {
 	    double doubleval = 0.0;
 	    FLDLEN32 doublelen  = sizeof (long);


### PR DESCRIPTION
Please add it to the master branch.

The first commit is for HP-UX issue - libcrypt.a is not that standard on HP-UX and I needed this patch to run on HP-UX 11

The 2nd commit is a simple hack to add short data type

The 3rd commit is something I kindly ask you to check as the description and naming was contradictory to values. it is possible that instead of values naming and description should be fixed.
